### PR TITLE
fix s3.ls KeyError when Contents not found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 # ------------------------------------------------
-# ckeck static files
+# check static files
 # ------------------------------------------------
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -17,24 +17,23 @@ repos:
         args: [--autofix]
 
 - repo: https://github.com/markdownlint/markdownlint
-  rev: v0.11.0
+  rev: v0.12.0
   hooks:
     - id: markdownlint
       # ignore line length of makrdownlint
       args: [-r, ~MD013]
 
-
 # ------------------------------------------------
-# ckeck python files
+# check python files
 # ------------------------------------------------
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 22.12.0
   hooks:
   - id: black
     language_version: python3
 
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     # max-line-length setting is the same as black

--- a/src/awspack/s3/s3.py
+++ b/src/awspack/s3/s3.py
@@ -55,7 +55,11 @@ class S3:
     """
 
     def ls(self, bucket_name: str, path: str) -> list:
-        return client.list_objects_v2(Bucket=bucket_name, Prefix=path)["Contents"]
+        res: dict = client.list_objects_v2(Bucket=bucket_name, Prefix=path)
+        if "Contents" in res:
+            return res["Contents"]
+        else:
+            return []
 
     """ select the objects on the s3 bucket with the S3 SQL expression.
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.select_object_content

--- a/test/ut_s3_bucket.py
+++ b/test/ut_s3_bucket.py
@@ -62,7 +62,16 @@ class UtEBucket(unittest.TestCase):
         self.assertEqual(actual[0]["Key"], expected)
         self.assertEqual(actual[1]["Key"], expected2)
 
-    def test_04_get(self):
+    def test_04_ls(self):
+        ut_arg: str = "404/"
+        expected = []
+        actual = self.s3.ls(bucket_name=self.bucket_name, path=ut_arg)
+        # type test
+        self.assertIs(type(actual), list)
+        # value test
+        self.assertEqual(actual, expected)
+
+    def test_05_get(self):
         ut_arg: str = "test/ut_test.json"
         expected = 200
         actual = self.bucket.get(path=ut_arg)
@@ -71,7 +80,7 @@ class UtEBucket(unittest.TestCase):
         # value test
         self.assertEqual(actual["ResponseMetadata"]["HTTPStatusCode"], expected)
 
-    def test_05_getContents(self):
+    def test_06_getContents(self):
         ut_arg: str = "test/ut_test.json"
         expected = '{"ut": "test"}'
         actual = self.bucket.getContents(path=ut_arg)
@@ -80,7 +89,7 @@ class UtEBucket(unittest.TestCase):
         # value test
         self.assertEqual(actual, expected)
 
-    def test_06_download(self):
+    def test_07_download(self):
         ut_arg: str = "./test/ut_test.json"
         ut_arg2: str = "test/ut_test.json"
         expected = None
@@ -88,7 +97,7 @@ class UtEBucket(unittest.TestCase):
         # value test
         self.assertEqual(actual, expected)
 
-    def test_07_delete(self):
+    def test_08_delete(self):
         ut_arg: str = "test/ut_test.json"
         expected = 204
         actual = self.bucket.delete(path=ut_arg)
@@ -97,7 +106,7 @@ class UtEBucket(unittest.TestCase):
         # value test
         self.assertEqual(actual["ResponseMetadata"]["HTTPStatusCode"], expected)
 
-    def test_08_delete(self):
+    def test_09_delete(self):
         ut_arg: str = "test/ut_test.txt"
         expected = 204
         actual = self.bucket.delete(path=ut_arg)


### PR DESCRIPTION
- #56 

- update pre-commit
- Contents" KeyError occurs in s3.ls if the target path is empty, so fix to return [] if empty.